### PR TITLE
fix: migrate openclaw/plugin-sdk to focused subpath imports

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -1,4 +1,4 @@
-import type { OpenClawPluginApi } from "openclaw/plugin-sdk";
+import type { OpenClawPluginApi } from "openclaw/plugin-sdk/core";
 import { handleServerChanBotWebhookRequest, serverChanBotPlugin } from "./src/channel.js";
 import { setServerChanBotRuntime } from "./src/runtime.js";
 

--- a/src/channel.ts
+++ b/src/channel.ts
@@ -1,11 +1,11 @@
 import type { IncomingMessage, ServerResponse } from "node:http";
 import type {
     ChannelAccountSnapshot,
-    ChannelPlugin,
     ChannelStatusIssue,
-    OpenClawConfig,
-} from "openclaw/plugin-sdk";
-import { DEFAULT_ACCOUNT_ID, buildChannelConfigSchema } from "openclaw/plugin-sdk";
+} from "openclaw/plugin-sdk/channel-contract";
+import type { ChannelPlugin, OpenClawConfig } from "openclaw/plugin-sdk/core";
+import { DEFAULT_ACCOUNT_ID } from "openclaw/plugin-sdk/account-id";
+import { buildChannelConfigSchema } from "openclaw/plugin-sdk/channel-config-schema";
 import { ServerChanBotConfigSchema } from "./config-schema.js";
 import {
     serverChanBotGetMe,

--- a/src/runtime.ts
+++ b/src/runtime.ts
@@ -1,4 +1,4 @@
-import type { PluginRuntime } from "openclaw/plugin-sdk";
+import type { PluginRuntime } from "openclaw/plugin-sdk/core";
 
 let runtime: PluginRuntime | null = null;
 


### PR DESCRIPTION
## Problem

OpenClaw 2026.3.31+ deprecated the catch-all `openclaw/plugin-sdk` import path (now mapped to `openclaw/plugin-sdk/compat`). This causes a runtime deprecation warning on every gateway startup:

```
[OPENCLAW_PLUGIN_SDK_COMPAT_DEPRECATED] Warning: openclaw/plugin-sdk/compat is deprecated for new plugins.
Migrate to focused openclaw/plugin-sdk/<subpath> imports.
See https://docs.openclaw.ai/plugins/sdk-migration
```

## Changes

Migrate all 3 source files to use focused subpath imports:

| Old import | New import | Symbols |
|---|---|---|
| `openclaw/plugin-sdk` | `openclaw/plugin-sdk/core` | `OpenClawPluginApi`, `ChannelPlugin`, `OpenClawConfig`, `PluginRuntime` |
| `openclaw/plugin-sdk` | `openclaw/plugin-sdk/channel-contract` | `ChannelAccountSnapshot`, `ChannelStatusIssue` |
| `openclaw/plugin-sdk` | `openclaw/plugin-sdk/account-id` | `DEFAULT_ACCOUNT_ID` |
| `openclaw/plugin-sdk/channel-config-schema` | _(unchanged)_ | `buildChannelConfigSchema` |

No functional changes — only import paths are updated.

## Tested

Verified the new subpath exports exist in OpenClaw 2026.4.1 (`/plugin-sdk/core`, `/plugin-sdk/channel-contract`, `/plugin-sdk/account-id`, `/plugin-sdk/channel-config-schema` all present in `package.json` exports map).